### PR TITLE
Included 'rlang' dependency 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ LazyData: true
 RoxygenNote: 7.1.0
 Depends: R (>= 3.1.0)
 Imports:
+  rlang,
   crayon,
   cli,
   progress,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## cmdlR v0.0.2
-*
+* Took dependence on 'rlang' to make work with environments and expression evaluation easier.
 
 ## cmdlR v0.0.1
 * Added a simple search for starting values function

--- a/R/cmdlR.R
+++ b/R/cmdlR.R
@@ -13,4 +13,5 @@
 #' @importFrom stats runif
 #' @import crayon
 #' @import cli
+#' @import rlang
 NULL


### PR DESCRIPTION
Included 'rlang' dependency to to make it easier to work with environments, expressions and code evaluation. This is non-breaking change and can be safely merged with master. 