### PR TITLE
id and ct indexes are inferred from the data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cmdlR
 Type: Package
 Title: Choice Modeling in R
-Version: 0.0.2
+Version: 0.0.2.9001
 Authors@R: person("Erlend", "Dancke Sandorf", email = "e.d.sandorf@stir.ac.uk", role = c("aut", "cre"))
 Maintainer: Erlend Dancke Sandorf <e.d.sandorf@stir.ac.uk>
 Description: The problem of choice is fundamental to economics. Choice models are used to understand how people make choices in markets. cmdlR is a set of wrapper functions around a user written log-likelihood function. The package also contain several functions to check for local-optima, calculate welfare measures, compare results and make predictions. To get started, the package contains several examples with pre-programmed log-likelihood functions that can be easily tweaked by the user.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## cmdlR v0.0.3
-
+* 'N', 'S' and 'nobs' are no longer specified in 'model_opt' but inferred from 
+the data using the data, id- and choice task variables.
 
 ## cmdlR v0.0.2
 * Added hybrid choice model example and a new mixed logit example. 

--- a/R/validate_model_opt.R
+++ b/R/validate_model_opt.R
@@ -41,6 +41,13 @@ validate_model_opt <- function(model_opt_input, db) {
     stop("You must specify the id, ct and choice variables in model_opt.")
   }
   
+  # Add N, S and nobs to model_opt
+  model_opt$N <- length(unique(db[[model_opt$id]]))
+  model_opt$S <- length(unique(db[[model_opt$ct]]))
+  # Note that this does not consider missing rows (maybe consider the choice var here?)
+  model_opt$nobs <- nrow(db)
+  
+  # Check the alt_avail option
   if (is.null(model_opt$alt_avail)) {
     message(red$bold(symbol$cross), "  model_opt().\n")
     stop("You must specify the list of alternative availabilities. It can be a list of variables indicating availability, or if the alternative is always available to all individuals, it can be the integer 1. Please see the provided examples for how this is implemented in practice.")

--- a/examples/iclv-ordered.R
+++ b/examples/iclv-ordered.R
@@ -35,15 +35,12 @@ model_opt <- list(
   id = "ID",
   ct = "task",
   choice = "best",
-  N = length(unique(db[["ID"]])),
-  S = length(unique(db[["task"]])),
   alt_avail = list(
     alt1 = 1,
     alt2 = 1,
     alt3 = 1, 
     alt4 = 1
   ),
-  nobs = nrow(db),
   fixed = c("b_brand_Artemis", "b_country_USA", "b_char_standard"),
   param = list(
     b_brand_Artemis    = 0, 

--- a/examples/lc.R
+++ b/examples/lc.R
@@ -34,13 +34,10 @@ model_opt <- list(
   id = "ID",
   ct = "ct",
   choice = "choice",
-  N = length(unique(db[["ID"]])),
-  S = length(unique(db[["ct"]])),
   alt_avail = list(
     alt1 = 1,
     alt2 = 1
   ),
-  nobs = nrow(db),
   fixed = c("b_asc_2", "g_const_2"),
   param = list(
     b_asc_1 = 0,

--- a/examples/mixl-uncorrelated-ln.R
+++ b/examples/mixl-uncorrelated-ln.R
@@ -34,13 +34,10 @@ model_opt <- list(
   id = "ID",
   ct = "ct",
   choice = "choice",
-  N = length(unique(db[["ID"]])),
-  S = length(unique(db[["ct"]])),
   alt_avail = list(
     alt1 = 1,
     alt2 = 1
   ),
-  nobs = nrow(db),
   fixed = c(),
   param = list(
     mu_log_b_tt    =-3,

--- a/examples/mixl.R
+++ b/examples/mixl.R
@@ -33,14 +33,11 @@ model_opt <- list(
   id = "id",
   ct = "ct",
   choice = "choice",
-  N = length(unique(db[["id"]])),
-  S = length(unique(db[["ct"]])),
   alt_avail = list(
     alt1 = 1,
     alt2 = 1, 
     alt3 = 1
   ),
-  nobs = nrow(db),
   mixing = TRUE,
   draws_type = "scrambled_sobol",
   R = 1000, 

--- a/examples/mnl.R
+++ b/examples/mnl.R
@@ -42,15 +42,12 @@ model_opt <- list(
   id = "ID",
   ct = "ct",
   choice = "choice",
-  N = length(unique(db[["ID"]])),
-  S = length(unique(db[["ct"]])),
   alt_avail = list(
     alt1 = "av_car",
     alt2 = "av_bus",
     alt3 = "av_air", 
     alt4 = "av_rail"
   ),
-  nobs = nrow(db),
   fixed = c("asc_car", "b_no_frills"),
   param = list(
     asc_car = 0,


### PR DESCRIPTION
Updated the code to use 'model_opt$id' and 'model_opt$ct' to infer the indexes N and S from 'db'. This ensures that there are fewer elements for the user to specify in 'model_opt'. Should make it easier to use with fewer things that can go wrong. 