### PR TITLE
Fixed bug with `collate()`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,4 +6,5 @@
 ^CRAN-RELEASE$
 ^docs$
 ^examples$
-^Ouputs$
+^Outputs$
+^outputs$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cmdlR
 Type: Package
 Title: Choice Modeling in R
-Version: 0.0.2.9002
+Version: 0.0.2.9003
 Authors@R: person("Erlend", "Dancke Sandorf", email = "e.d.sandorf@stir.ac.uk", role = c("aut", "cre"))
 Maintainer: Erlend Dancke Sandorf <e.d.sandorf@stir.ac.uk>
 Description: The problem of choice is fundamental to economics. Choice models are used to understand how people make choices in markets. cmdlR is a set of wrapper functions around a user written log-likelihood function. The package also contain several functions to check for local-optima, calculate welfare measures, compare results and make predictions. To get started, the package contains several examples with pre-programmed log-likelihood functions that can be easily tweaked by the user.

--- a/R/collate.R
+++ b/R/collate.R
@@ -48,9 +48,10 @@ collate <- function(path = NULL, pattern = NULL, digits = 4) {
   # Extract the names and create a matrix to use for matching
   # This works, but it does it alphabetically and numerically - extension here?
   row_names <- c(
-    unique(sort(Reduce(c, lapply(models, function(x) names(x$coef))))),
+    unique(sort(Reduce(c, lapply(models, function(x) names(x$param_final))))),
     "name", "nobs", "K", "ll", "adj_rho_sqrd", "bic", "aic", "draws_type", "R"
   )
+  
   results <- matrix(NA, nrow = length(row_names), ncol = (length(models) * 2),
                     dimnames = list(
                       row_names,
@@ -64,7 +65,7 @@ collate <- function(path = NULL, pattern = NULL, digits = 4) {
     i_se <- i_est + 1
     
     # Extract the coefficients, calculate the standard errors and place into matrix
-    coef_tmp <- round(models[[i]][["coef"]], digits)
+    coef_tmp <- round(models[[i]][["param_final"]], digits)
     se_tmp <- round(sqrt(diag(models[[i]][["vcov"]])), digits)
     results[names(coef_tmp), i_est] <- coef_tmp
     results[names(se_tmp), i_se] <- se_tmp
@@ -72,7 +73,7 @@ collate <- function(path = NULL, pattern = NULL, digits = 4) {
     # Extrac the model name and characteristics and append to the matrix
     results["name", i_est] <- models[[i]][["name"]]
     results["nobs", i_est] <- models[[i]][["nobs"]]
-    results["K", i_est] <- length(models[[i]][["coef"]])
+    results["K", i_est] <- length(models[[i]][["param_final"]])
     results["ll", i_est] <- round(models[[i]][["ll"]], digits)
     results["adj_rho_sqrd", i_est] <- round(models[[i]][["adj_rho_sqrd"]], digits)
     results["bic", i_est] <- round(models[[i]][["bic"]], digits)
@@ -85,5 +86,6 @@ collate <- function(path = NULL, pattern = NULL, digits = 4) {
   # Write the .csv file to the outputs folder
   file_path <- paste0(path, "-collated-results.csv")
   utils::write.csv(results, file_path)
-  cat(blue$bold(symbol$info), paste0("  The collated results are saved to: \"", file_path, "\"\n"))
+  message(blue$bold(symbol$info), paste0("  Robust standard errors are not included in the collated file.\n"))
+  message(blue$bold(symbol$info), paste0("  The collated results are saved to: \"", file_path, "\"\n"))
 }


### PR DESCRIPTION
The `collate()` function was pulling parameters from the list element `coef`, but final parameters are no longer stored here. This caused the function to fail. 

Provided a simple bug fix where the final parameters are now pulled from `final_param`. 