### PR TITLE
Specified error function for vcov tryCatch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cmdlR
 Type: Package
 Title: Choice Modeling in R
-Version: 0.0.2.9003
+Version: 0.0.2.9004
 Authors@R: person("Erlend", "Dancke Sandorf", email = "e.d.sandorf@stir.ac.uk", role = c("aut", "cre"))
 Maintainer: Erlend Dancke Sandorf <e.d.sandorf@stir.ac.uk>
 Description: The problem of choice is fundamental to economics. Choice models are used to understand how people make choices in markets. cmdlR is a set of wrapper functions around a user written log-likelihood function. The package also contain several functions to check for local-optima, calculate welfare measures, compare results and make predictions. To get started, the package contains several examples with pre-programmed log-likelihood functions that can be easily tweaked by the user.

--- a/R/estimate.R
+++ b/R/estimate.R
@@ -351,6 +351,9 @@ estimate <- function(ll, db, estim_opt, model_opt, save_opt, debug = FALSE) {
       colnames(vcov) <- names(model[["param_final"]])
       rownames(vcov) <- names(model[["param_final"]])
       vcov
+    }, error = function(e) {
+      message(red$bold(symbol$cross), "  Failed to calculate the variance covariance matrix.\n")
+      NULL
     })
     
     # Calculate the robust variance-covariance matrix


### PR DESCRIPTION
The tryCatch for the calculation of the variance covariance matrix didn't include an error function to execute and would result in late time failure if the variance covariance matrix could not be computed. 